### PR TITLE
Feature/convention over configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ before_script:
 
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.xml
-  - vendor/bin/phpcs -pn --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests
+  - vendor/bin/phpcs -pn --extensions=php --ignore=./config/Migrations/* --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests ./config
+  - vendor/bin/phpcs --colors -p --ignore=./config/Migrations/* --standard=vendor/scherersoftware/coding-standard/scherersoftware ./src ./tests ./config
+  - php -d memory_limit=-1 vendor/bin/phpstan analyse -c phpstan.neon -l 1 ./src
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
+  - 7.1
 
 services:
   - mysql

--- a/README.md
+++ b/README.md
@@ -190,8 +190,7 @@ $this->addBehavior('ModelHistory.Historizable', [
         'action' => 'index'
     ],
     'fields' => [
-        [
-            'name' => 'firstname',
+        'firstname' => [
             'translation' => function () {
                 return __('user.firstname');
             },

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,11 @@
         "codekanzlei/cake-frontend-bridge": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "6.3.*",
-        "cakephp/cakephp": "3.4.*",
-        "cakephp/cakephp-codesniffer": "dev-master"
+        "phpunit/phpunit": "^6.0",
+        "cakephp/cakephp": "^3.4",
+        "phpstan/phpstan": "^0.8",
+        "cakephp/cakephp-codesniffer": "^3.0",
+        "scherersoftware/coding-standard": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,13 @@
         "installer-name": "ModelHistory"
     },
     "require": {
-        "php": ">=5.4",
+        "php": ">=7.1",
         "codekanzlei/cake-cktools": "^1.3",
         "codekanzlei/cake-frontend-bridge": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
-        "cakephp/cakephp": "3.3.*",
+        "phpunit/phpunit": "6.3.*",
+        "cakephp/cakephp": "3.4.*",
         "cakephp/cakephp-codesniffer": "dev-master"
     },
     "autoload": {

--- a/config/Migrations/20161115113859_Initial.php
+++ b/config/Migrations/20161115113859_Initial.php
@@ -1,9 +1,10 @@
 <?php
+declare(strict_types = 1);
 use Migrations\AbstractMigration;
 
 class Initial extends AbstractMigration
 {
-    public function up()
+    public function up(): void
     {
 
         $this->table('model_history', ['id' => false, 'primary_key' => ['id']])
@@ -72,7 +73,7 @@ class Initial extends AbstractMigration
             ->create();
     }
 
-    public function down()
+    public function down(): void
     {
         $this->dropTable('model_history');
     }

--- a/config/Migrations/20170517155503_AddModelHistorySaveHash.php
+++ b/config/Migrations/20170517155503_AddModelHistorySaveHash.php
@@ -1,10 +1,11 @@
 <?php
+declare(strict_types = 1);
 use Migrations\AbstractMigration;
 
 class AddModelHistorySaveHash extends AbstractMigration
 {
 
-    public function up()
+    public function up(): void
     {
 
         $this->table('model_history')
@@ -17,7 +18,7 @@ class AddModelHistorySaveHash extends AbstractMigration
             ->update();
     }
 
-    public function down()
+    public function down(): void
     {
 
         $this->table('model_history')

--- a/config/routes.php
+++ b/config/routes.php
@@ -1,6 +1,7 @@
 <?php
+declare(strict_types = 1);
 use Cake\Routing\Router;
 
-Router::plugin('ModelHistory', [], function ($routes) {
+Router::plugin('ModelHistory', [], function ($routes): void {
     $routes->fallbacks('DashedRoute');
 });

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,3 @@
+parameters:
+    ignoreErrors:
+        - '#Class App\\Controller\\AppController not found and could not be autoloaded.#'

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -1,8 +1,0 @@
-<?php
-namespace ModelHistory\Controller;
-
-use App\Controller\AppController as BaseController;
-
-class AppController extends BaseController
-{
-}

--- a/src/Controller/ModelHistoryController.php
+++ b/src/Controller/ModelHistoryController.php
@@ -2,12 +2,12 @@
 declare(strict_types = 1);
 namespace ModelHistory\Controller;
 
+use App\Controller\AppController;
 use Cake\Http\Response;
 use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 use Cake\Utility\Text;
-use App\Controller\AppController;
 
 class ModelHistoryController extends AppController
 {

--- a/src/Controller/ModelHistoryController.php
+++ b/src/Controller/ModelHistoryController.php
@@ -3,6 +3,7 @@ namespace ModelHistory\Controller;
 
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
+use Cake\Http\Response;
 use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
@@ -45,7 +46,16 @@ class ModelHistoryController extends AppController
      * @param  string  $columnClass     div classes for column
      * @return void
      */
-    public function index($model = null, $foreignKey = null, $limit = null, $page = null, $showFilterBox = null, $showCommentBox = null, $includeAssociated = null, $columnClass = '')
+    public function index(
+        $model = null,
+        $foreignKey = null,
+        $limit = null,
+        $page = null,
+        $showFilterBox = null,
+        $showCommentBox = null,
+        $includeAssociated = null,
+        $columnClass = ''
+    ): void
     {
         $this->ModelHistory->belongsTo('Users', [
             'foreignKey' => 'user_id'
@@ -95,9 +105,18 @@ class ModelHistoryController extends AppController
      * @param  bool    $showFilterBox   Show Filter Box
      * @param  bool    $showCommentBox  Show comment Box
      * @param  string  $columnClass     div classes for column
-     * @return string                   Index View
+     * @return \Cake\Http\Response      Index View
      */
-    public function filter($model = null, $foreignKey = null, $limit = null, $page = null, $showFilterBox = null, $showCommentBox = null, $includeAssociated = null, $columnClass = '')
+    public function filter(
+        $model = null,
+        $foreignKey = null,
+        $limit = null,
+        $page = null,
+        $showFilterBox = null,
+        $showCommentBox = null,
+        $includeAssociated = null,
+        $columnClass = ''
+    ): Response
     {
         $this->request->allowMethod(['post']);
 
@@ -203,7 +222,7 @@ class ModelHistoryController extends AppController
      * @param  string   $currentId   UUID of ModelHistory entry to get diff for
      * @return void
      */
-    public function diff($currentId = null)
+    public function diff($currentId = null): void
     {
         $historyEntry = $this->ModelHistory->get($currentId);
         $this->FrontendBridge->setBoth('diffOutput', $this->ModelHistory->buildDiff($historyEntry));

--- a/src/Controller/ModelHistoryController.php
+++ b/src/Controller/ModelHistoryController.php
@@ -55,8 +55,7 @@ class ModelHistoryController extends AppController
         $showCommentBox = null,
         $includeAssociated = null,
         $columnClass = ''
-    ): void
-    {
+    ): void {
         $this->ModelHistory->belongsTo('Users', [
             'foreignKey' => 'user_id'
         ]);
@@ -116,8 +115,7 @@ class ModelHistoryController extends AppController
         $showCommentBox = null,
         $includeAssociated = null,
         $columnClass = ''
-    ): Response
-    {
+    ): Response {
         $this->request->allowMethod(['post']);
 
         $filterConditions = [];

--- a/src/Controller/ModelHistoryController.php
+++ b/src/Controller/ModelHistoryController.php
@@ -1,15 +1,13 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistory\Controller;
 
-use Cake\Core\Configure;
-use Cake\Core\Plugin;
 use Cake\Http\Response;
 use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 use Cake\Utility\Text;
-use FrontendBridge\Lib\ServiceResponse;
-use ModelHistory\Controller\AppController;
+use App\Controller\AppController;
 
 class ModelHistoryController extends AppController
 {
@@ -28,33 +26,34 @@ class ModelHistoryController extends AppController
      *
      * @return void
      */
-    public function initialize()
+    public function initialize(): void
     {
         $this->loadModel('ModelHistory.ModelHistory');
         parent::initialize();
     }
 
     /**
-     * index function
+     * Index function
      *
-     * @param  string $model           name of the model
-     * @param  string $foreignKey      id of the entity
-     * @param  int    $limit           Items to show
-     * @param  int    $page            Current page
-     * @param  bool   $showFilterBox   Show Filter Box
-     * @param  bool   $showCommentBox  Show comment Box
-     * @param  string  $columnClass     div classes for column
+     * @param string $model Name of the model
+     * @param string $foreignKey Id of the entity
+     * @param int $limit Items to show
+     * @param int $page Current page
+     * @param bool $showFilterBox Show Filter Box
+     * @param bool $showCommentBox Show comment Box
+     * @param mixed $includeAssociated Included Assocation
+     * @param string  $columnClass Div classes for column
      * @return void
      */
     public function index(
-        $model = null,
-        $foreignKey = null,
-        $limit = null,
-        $page = null,
-        $showFilterBox = null,
-        $showCommentBox = null,
+        string $model = null,
+        string $foreignKey = null,
+        int $limit = null,
+        int $page = null,
+        bool $showFilterBox = null,
+        bool $showCommentBox = null,
         $includeAssociated = null,
-        $columnClass = ''
+        string $columnClass = ''
     ): void {
         $this->ModelHistory->belongsTo('Users', [
             'foreignKey' => 'user_id'
@@ -97,24 +96,25 @@ class ModelHistoryController extends AppController
     /**
      * Load entries and filter them if necessary.
      *
-     * @param  string  $model           Model name
-     * @param  string  $foreignKey      Model's foreign key
-     * @param  int     $limit           Entries limit
-     * @param  int     $page            Current page to view
-     * @param  bool    $showFilterBox   Show Filter Box
-     * @param  bool    $showCommentBox  Show comment Box
-     * @param  string  $columnClass     div classes for column
-     * @return \Cake\Http\Response      Index View
+     * @param string $model Model name
+     * @param string $foreignKey Model's foreign key
+     * @param int $limit Entries limit
+     * @param int $page Current page to view
+     * @param bool $showFilterBox Show Filter Box
+     * @param bool $showCommentBox Show comment Box
+     * @param mixed $includeAssociated Included Assocation
+     * @param string  $columnClass Div classes for column
+     * @return \Cake\Http\Response Index View
      */
     public function filter(
-        $model = null,
-        $foreignKey = null,
-        $limit = null,
-        $page = null,
-        $showFilterBox = null,
-        $showCommentBox = null,
+        string $model = null,
+        string $foreignKey = null,
+        int $limit = null,
+        int $page = null,
+        bool $showFilterBox = null,
+        bool $showCommentBox = null,
         $includeAssociated = null,
-        $columnClass = ''
+        string $columnClass = ''
     ): Response {
         $this->request->allowMethod(['post']);
 
@@ -220,7 +220,7 @@ class ModelHistoryController extends AppController
      * @param  string   $currentId   UUID of ModelHistory entry to get diff for
      * @return void
      */
-    public function diff($currentId = null): void
+    public function diff(string $currentId = null): void
     {
         $historyEntry = $this->ModelHistory->get($currentId);
         $this->FrontendBridge->setBoth('diffOutput', $this->ModelHistory->buildDiff($historyEntry));

--- a/src/Model/Behavior/HistorizableBehavior.php
+++ b/src/Model/Behavior/HistorizableBehavior.php
@@ -62,7 +62,7 @@ class HistorizableBehavior extends Behavior
      * @param array $config The configuration settings provided to this behavior.
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         // Set default translations
         $this->config('translations', [
@@ -189,7 +189,7 @@ class HistorizableBehavior extends Behavior
      * @param ArrayObject $options Additional options
      * @return void
      */
-    public function beforeSave(Event $event, EntityInterface $entity, \ArrayObject $options)
+    public function beforeSave(Event $event, EntityInterface $entity, \ArrayObject $options): void
     {
         if (!$entity->isNew() && $entity->dirty()) {
             $saveHash = Security::hash(md5(uniqid()));
@@ -208,7 +208,7 @@ class HistorizableBehavior extends Behavior
      *
      * @return array
      */
-    protected function _extractDirtyFields(EntityInterface $entity)
+    protected function _extractDirtyFields(EntityInterface $entity): array
     {
         $dirtyFields = [];
         $fields = array_keys($entity->toArray());
@@ -225,7 +225,7 @@ class HistorizableBehavior extends Behavior
      * @param  string           $saveHash  Hash to identify save process
      * @return bool
      */
-    protected function _applySaveHash(EntityInterface $entity, $saveHash)
+    protected function _applySaveHash(EntityInterface $entity, string $saveHash): bool
     {
         $output = [];
         if (defined('PHPUNIT_TESTSUITE')) {
@@ -251,6 +251,8 @@ class HistorizableBehavior extends Behavior
             $object->save_hash = $saveHash;
             $object->dirty('save_hash', false);
         }
+
+        return true;
     }
 
     /**
@@ -260,7 +262,7 @@ class HistorizableBehavior extends Behavior
      * @param  EntityInterface  $object  Object to use
      * @return null|object
      */
-    protected function _recursivelyExtractObject($path, EntityInterface $object)
+    protected function _recursivelyExtractObject(string $path, EntityInterface $object): ?EntityInterface
     {
         if (stripos($path, '.') !== false) {
             $split = explode('.', $path);
@@ -283,7 +285,7 @@ class HistorizableBehavior extends Behavior
      * @param EntityInterface $entity Entity that was saved
      * @return void
      */
-    public function afterSave(Event $event, EntityInterface $entity)
+    public function afterSave(Event $event, EntityInterface $entity): void
     {
         $action = $entity->isNew() ? ModelHistory::ACTION_CREATE : ModelHistory::ACTION_UPDATE;
 
@@ -306,7 +308,7 @@ class HistorizableBehavior extends Behavior
      * @param ArrayObject $options Additional options
      * @return void
      */
-    public function afterDelete(Event $event, EntityInterface $entity, $options)
+    public function afterDelete(Event $event, EntityInterface $entity, \ArrayObject $options): void
     {
         $this->ModelHistory->add($entity, ModelHistory::ACTION_DELETE, $this->_getUserId());
     }
@@ -319,7 +321,7 @@ class HistorizableBehavior extends Behavior
      * @param string $userId Commenting User
      * @return ModelHistory
      */
-    public function addCommentToHistory(EntityInterface $entity, $comment, $userId = null)
+    public function addCommentToHistory(EntityInterface $entity, string $comment, string $userId = null)
     {
         if (!$userId) {
             $userId = $this->_getUserId();
@@ -333,7 +335,7 @@ class HistorizableBehavior extends Behavior
      *
      * @return string|null
      */
-    protected function _getUserId()
+    protected function _getUserId(): ?string
     {
         $userId = null;
         $callback = $this->config('userIdCallback');
@@ -351,7 +353,7 @@ class HistorizableBehavior extends Behavior
      * @param  string  $fieldValue  Value
      * @return string
      */
-    public function getRelationLink($fieldName, $fieldValue = null)
+    public function getRelationLink(string $fieldName, string $fieldValue = null): string
     {
         $tableName = Inflector::camelize(Inflector::pluralize(str_replace('_id', '', $fieldName)));
 
@@ -397,7 +399,7 @@ class HistorizableBehavior extends Behavior
      * @param callable $callback Callback which must return the user id
      * @return void
      */
-    public function setModelHistoryUserIdCallback(callable $callback)
+    public function setModelHistoryUserIdCallback(callable $callback): void
     {
         $this->config('userIdCallback', $callback);
     }
@@ -408,7 +410,7 @@ class HistorizableBehavior extends Behavior
      * @param  bool $withoutModel set to true to only get the field names without model name
      * @return array
      */
-    public function getUserNameFields($withoutModel = false)
+    public function getUserNameFields(bool $withoutModel = false): array
     {
         $userNameFields = $this->config('userNameFields');
         if ($withoutModel) {
@@ -428,7 +430,7 @@ class HistorizableBehavior extends Behavior
      *
      * @return int
      */
-    public function getEntriesLimit()
+    public function getEntriesLimit(): int
     {
         return $this->config('entriesToShow');
     }
@@ -438,7 +440,7 @@ class HistorizableBehavior extends Behavior
      *
      * @return array
      */
-    public function getFields()
+    public function getFields(): array
     {
         return $this->getConfig('fields');
     }
@@ -448,7 +450,7 @@ class HistorizableBehavior extends Behavior
      *
      * @return array
      */
-    public function getUrl()
+    public function getUrl(): array
     {
         if (is_array($this->config('url'))) {
             return $this->config('url');
@@ -462,7 +464,7 @@ class HistorizableBehavior extends Behavior
      *
      * @return array
      */
-    public function getTranslatedFields()
+    public function getTranslatedFields(): array
     {
         return Hash::apply($this->config('fields'), '{*}[searchable=true]', function ($array) {
             $formatted = [];
@@ -479,7 +481,7 @@ class HistorizableBehavior extends Behavior
      *
      * @return array
      */
-    public function getSaveableFields()
+    public function getSaveableFields(): array
     {
         return Hash::apply($this->config('fields'), '{*}[saveable=true]', function ($array) {
             $formatted = [];
@@ -496,7 +498,7 @@ class HistorizableBehavior extends Behavior
      *
      * @return array
      */
-    public function getAssociations()
+    public function getAssociations(): array
     {
         return $this->config('associations');
     }

--- a/src/Model/Behavior/HistorizableBehavior.php
+++ b/src/Model/Behavior/HistorizableBehavior.php
@@ -1,11 +1,11 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistory\Model\Behavior;
 
 use Cake\Core\Exception\Exception;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\ORM\Behavior;
-use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
@@ -44,7 +44,7 @@ class HistorizableBehavior extends Behavior
     /**
      * Instance of the ModelHistoryTable model
      *
-     * @var ModelHistoryTable
+     * @var \ModelHistory\Model\Table\ModelHistoryTable
      */
     public $ModelHistory;
 
@@ -321,7 +321,7 @@ class HistorizableBehavior extends Behavior
      * @param string $userId Commenting User
      * @return ModelHistory
      */
-    public function addCommentToHistory(EntityInterface $entity, string $comment, string $userId = null)
+    public function addCommentToHistory(EntityInterface $entity, string $comment, string $userId = null): ModelHistory
     {
         if (!$userId) {
             $userId = $this->_getUserId();

--- a/src/Model/Entity/HistoryContextTrait.php
+++ b/src/Model/Entity/HistoryContextTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace ModelHistory\Model\Entity;
 
@@ -13,20 +14,38 @@ use InvalidArgumentException;
  */
 trait HistoryContextTrait
 {
+
+    /**
+     * Context
+     *
+     * @var mixed
+     */
     protected $_context = null;
+
+    /**
+     * Context slug
+     *
+     * @var mixed
+     */
     protected $_contextSlug = null;
+
+    /**
+     * Context type
+     *
+     * @var mixed
+     */
     protected $_contextType = null;
 
     /**
      * Sets a context given through a request to identify the creation
      * point of the revision.
      *
-     * @param string  $type        Context type
-     * @param object  $dataObject  Optional dataobject to get additional data from
-     * @param string  $slug        Optional slug. Must implement getContexts() when using
+     * @param string $type Context type
+     * @param object $dataObject Optional dataobject to get additional data from
+     * @param string $slug Optional slug. Must implement getContexts() when using
      * @return void
      */
-    public function setHistoryContext($type, $dataObject = null, $slug = null)
+    public function setHistoryContext(string $type, $dataObject = null, $slug = null): void
     {
         if (!in_array($type, array_keys(ModelHistory::getContextTypes()))) {
             throw new InvalidArgumentException("$type is not allowed as context type. Allowed types are: " . implode(', ', ModelHistory::getContextTypes()));
@@ -94,7 +113,7 @@ trait HistoryContextTrait
      *
      * @return array
      */
-    public function getHistoryContext()
+    public function getHistoryContext(): ?array
     {
         return $this->_context;
     }
@@ -104,7 +123,7 @@ trait HistoryContextTrait
      *
      * @return string
      */
-    public function getHistoryContextSlug()
+    public function getHistoryContextSlug(): ?string
     {
         return $this->_contextSlug;
     }
@@ -114,7 +133,7 @@ trait HistoryContextTrait
      *
      * @return string
      */
-    public function getHistoryContextType()
+    public function getHistoryContextType(): ?string
     {
         return $this->_contextType;
     }

--- a/src/Model/Entity/ModelHistory.php
+++ b/src/Model/Entity/ModelHistory.php
@@ -1,8 +1,8 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistory\Model\Entity;
 
 use Cake\ORM\Entity;
-use Cake\ORM\TableRegistry;
 
 /**
  * ModelHistory Entity.
@@ -40,10 +40,10 @@ class ModelHistory extends Entity
     /**
      * getter for data
      *
-     * @param string $data data
+     * @param array $data data
      * @return array
      */
-    protected function _getData($data)
+    protected function _getData(array $data): array
     {
         // Stringify empty values
         if (!empty($data)) {
@@ -58,7 +58,7 @@ class ModelHistory extends Entity
     /**
      * Transform null and boolean values to their string representation.
      *
-     * @param  mixed  $value  The Value to be checked
+     * @param  mixed  $value The Value to be checked
      * @return mixed
      */
     protected function _stringifyEmptyValue($value)
@@ -77,7 +77,7 @@ class ModelHistory extends Entity
      *
      * @return array
      */
-    public static function getContextTypes()
+    public static function getContextTypes(): array
     {
         return [
             self::CONTEXT_TYPE_CONTROLLER => __d('model_history', 'context.type.controller'),

--- a/src/Model/Table/ModelHistoryTable.php
+++ b/src/Model/Table/ModelHistoryTable.php
@@ -346,14 +346,14 @@ class ModelHistoryTable extends Table
      * Get Model History
      *
      * @param string $model Model name
-     * @param string $foreignKey Foreign key
+     * @param mixed $foreignKey Foreign key
      * @param int $itemsToShow Amount of items to be shown
      * @param int $page Current position
      * @param array $conditions Additional conditions for find
      * @param array $options Additional options
      * @return array
      */
-    public function getModelHistory(string $model, string $foreignKey, int $itemsToShow, int $page, array $conditions = [], array $options = []): array
+    public function getModelHistory(string $model, $foreignKey, int $itemsToShow, int $page, array $conditions = [], array $options = []): array
     {
         $conditions = Hash::merge([
             'model' => $model,
@@ -393,11 +393,11 @@ class ModelHistoryTable extends Table
      * Get Model History entries count
      *
      * @param string $model model name
-     * @param string $foreignKey foreign key
+     * @param mixed $foreignKey foreign key
      * @param array $conditions additional conditions for find
      * @return int
      */
-    public function getModelHistoryCount(string $model, string $foreignKey, array $conditions = [], array $options = []): int
+    public function getModelHistoryCount(string $model, $foreignKey, array $conditions = [], array $options = []): int
     {
         $conditions = Hash::merge([
             'model' => $model,

--- a/src/Model/Table/ModelHistoryTable.php
+++ b/src/Model/Table/ModelHistoryTable.php
@@ -107,9 +107,6 @@ class ModelHistoryTable extends Table
         } else {
             foreach ($saveableFields as $fieldName => $data) {
                 if (isset($options['data'][$fieldName])) {
-                    if ($data['obfuscated'] === true) {
-                        $options['data'][$fieldName] = '****************';
-                    }
                     if (isset($data['saveParser']) && is_callable($data['saveParser'])) {
                         $callback = $data['saveParser'];
                         $options['data'][$fieldName] = $callback($fieldName, $options['data'][$fieldName], $entity);
@@ -133,6 +130,9 @@ class ModelHistoryTable extends Table
                                 $options['data'][$fieldName] = $filterClass->save($fieldName, $data, $entity);
                             }
                         }
+                    }
+                    if ($data['obfuscated'] === true) {
+                        $options['data'][$fieldName] = '****************';
                     }
                     $saveFields[$fieldName] = $options['data'][$fieldName];
                 }

--- a/src/Model/Table/ModelHistoryTable.php
+++ b/src/Model/Table/ModelHistoryTable.php
@@ -1,11 +1,8 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistory\Model\Table;
 
 use Cake\Datasource\EntityInterface;
-use Cake\I18n\Date;
-use Cake\I18n\Time;
-use Cake\ORM\Query;
-use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
@@ -26,7 +23,7 @@ class ModelHistoryTable extends Table
      * @param array $config The configuration for the Table.
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         $this->table('model_history');
         $this->displayField('id');
@@ -45,7 +42,7 @@ class ModelHistoryTable extends Table
      * @param \Cake\Validation\Validator $validator Validator instance.
      * @return \Cake\Validation\Validator
      */
-    public function validationDefault(Validator $validator)
+    public function validationDefault(Validator $validator): \Cake\Validation\Validator
     {
         $validator->add('data', 'custom', [
             'rule' => function ($value, $context) {
@@ -70,7 +67,7 @@ class ModelHistoryTable extends Table
      * @param array $options Additional options
      * @return ModelHistory|false
      */
-    public function add(EntityInterface $entity, $action, $userId = null, array $options = [])
+    public function add(EntityInterface $entity, string $action, string $userId = null, array $options = [])
     {
         $options = Hash::merge([
             'dirtyFields' => null,
@@ -174,6 +171,7 @@ class ModelHistoryTable extends Table
             $contextType = $entity->getHistoryContextType();
         }
 
+        $entry = false;
         if (!empty($entries)) {
             foreach ($entries as $entry) {
                 $entry = $this->patchEntity($entry, [
@@ -208,11 +206,11 @@ class ModelHistoryTable extends Table
     /**
      * Transforms data fields to human readable form
      *
-     * @param  array   $history  Data
-     * @param  string  $model    Model name
+     * @param array $history Data
+     * @param string $model Model name
      * @return array
      */
-    protected function _transformDataFields(array $history, $model)
+    protected function _transformDataFields(array $history, string $model): array
     {
         $tableConfig = [];
         if (defined('PHPUNIT_TESTSUITE')) {
@@ -248,7 +246,7 @@ class ModelHistoryTable extends Table
      * @param string $userId User which wrote the note
      * @return ModelHistory
      */
-    public function addComment(EntityInterface $entity, $comment, $userId = null)
+    public function addComment(EntityInterface $entity, string $comment, string $userId = null): ModelHistory
     {
         $add = $this->add($entity, ModelHistory::ACTION_COMMENT, $userId, [
             'data' => [
@@ -265,7 +263,7 @@ class ModelHistoryTable extends Table
      * @param EntityInterface $entity Entity to get the revision number for
      * @return int
      */
-    public function getNextRevisionNumberForEntity(EntityInterface $entity)
+    public function getNextRevisionNumberForEntity(EntityInterface $entity): int
     {
         $revision = 1;
         $last = $this->find()
@@ -291,7 +289,7 @@ class ModelHistoryTable extends Table
      * @param EntityInterface $entity Entity
      * @return string
      */
-    public function getEntityModel(EntityInterface $entity)
+    public function getEntityModel(EntityInterface $entity): string
     {
         $source = $entity->source();
         if (substr($source, -5) == 'Table') {
@@ -302,14 +300,14 @@ class ModelHistoryTable extends Table
     }
 
     /**
-     * getEntityWithHistory function
+     * GetEntityWithHistory function
      *
-     * @param string  $model          Model
-     * @param string  $foreignKey     ForeignKey
-     * @param array   $options        Options
-     * @return Entity
+     * @param string $model Model
+     * @param string $foreignKey ForeignKey
+     * @param array $options Options
+     * @return \Cake\Datasource\EntityInterface
      */
-    public function getEntityWithHistory($model, $foreignKey, array $options = [])
+    public function getEntityWithHistory(string $model, string $foreignKey, array $options = []): EntityInterface
     {
         $tableConfig = [];
         if (defined('PHPUNIT_TESTSUITE')) {
@@ -345,17 +343,17 @@ class ModelHistoryTable extends Table
     }
 
     /**
-     * get Model History
+     * Get Model History
      *
-     * @param string  $model        model name
-     * @param string  $foreignKey   foreign key
-     * @param int     $itemsToShow  Amount of items to be shown
-     * @param int     $page         Current position
-     * @param array   $conditions   additional conditions for find
-     * @param array   $options      Additional options
+     * @param string $model Model name
+     * @param string $foreignKey Foreign key
+     * @param int $itemsToShow Amount of items to be shown
+     * @param int $page Current position
+     * @param array $conditions Additional conditions for find
+     * @param array $options Additional options
      * @return array
      */
-    public function getModelHistory($model, $foreignKey, $itemsToShow, $page, array $conditions = [], array $options = [])
+    public function getModelHistory(string $model, string $foreignKey, int $itemsToShow, int $page, array $conditions = [], array $options = []): array
     {
         $conditions = Hash::merge([
             'model' => $model,
@@ -392,14 +390,14 @@ class ModelHistoryTable extends Table
     }
 
     /**
-     * get Model History entries count
+     * Get Model History entries count
      *
-     * @param string $model         model name
-     * @param string $foreignKey    foreign key
-     * @param array  $conditions    additional conditions for find
+     * @param string $model model name
+     * @param string $foreignKey foreign key
+     * @param array $conditions additional conditions for find
      * @return int
      */
-    public function getModelHistoryCount($model, $foreignKey, array $conditions = [], array $options = [])
+    public function getModelHistoryCount(string $model, string $foreignKey, array $conditions = [], array $options = []): int
     {
         $conditions = Hash::merge([
             'model' => $model,
@@ -432,7 +430,7 @@ class ModelHistoryTable extends Table
      * @param  ModelHistory  $historyEntry  ModelHistory Entry to build diff for
      * @return array
      */
-    public function buildDiff(ModelHistory $historyEntry)
+    public function buildDiff(ModelHistory $historyEntry): array
     {
         if ($historyEntry->revision == 1) {
             return [];
@@ -575,7 +573,7 @@ class ModelHistoryTable extends Table
      * @param  string  $model      Model
      * @return string
      */
-    protected function _translateFieldname($fieldname, $model)
+    protected function _translateFieldname(string $fieldname, string $model): string
     {
         // Try to get the generic model.field translation string
         $localeSlug = strtolower(Inflector::singularize(Inflector::delimit($model))) . '.' . strtolower($fieldname);

--- a/src/Model/Transform/ArrayTransform.php
+++ b/src/Model/Transform/ArrayTransform.php
@@ -1,21 +1,34 @@
 <?php
+declare(strict_types = 1);
 
 namespace ModelHistory\Model\Transform;
+
+use Cake\Datasource\EntityInterface;
 
 class ArrayTransform extends Transform
 {
     /**
-     * {@inheritDoc}
+     * Amend the data before saving.
+     *
+     * @param string $fieldname Field name
+     * @param array $config field config
+     * @param \Cake\Datasource\EntityInterface $entity entity
+     * @return mixed
      */
-    public function save($fieldname, $config, $entity)
+    public function save(string $fieldname, array $config, EntityInterface $entity)
     {
          return $entity->$fieldname;
     }
 
     /**
-     * {@inheritDoc}
+     * Amend the data before displaying.
+     *
+     * @param string $fieldname Field name
+     * @param mixed  $value Value to be amended
+     * @param string $model Optional model to be used
+     * @return mixed
      */
-    public function display($fieldname, $value, $model = null)
+    public function display(string $fieldname, $value, string $model = null)
     {
         if (is_array($value)) {
             $return = '';

--- a/src/Model/Transform/AssociationTransform.php
+++ b/src/Model/Transform/AssociationTransform.php
@@ -1,24 +1,36 @@
 <?php
+declare(strict_types = 1);
 
 namespace ModelHistory\Model\Transform;
 
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 
 class AssociationTransform extends Transform
 {
     /**
-     * {@inheritDoc}
+     * Amend the data before saving.
+     *
+     * @param string $fieldname Field name
+     * @param array $config field config
+     * @param \Cake\Datasource\EntityInterface $entity entity
+     * @return mixed
      */
-    public function save($fieldname, $config, $entity = null)
+    public function save(string $fieldname, array $config, EntityInterface $entity = null)
     {
         return $entity[$config['associationKey']];
     }
 
     /**
-     * {@inheritDoc}
+     * Amend the data before displaying.
+     *
+     * @param string $fieldname Field name
+     * @param mixed  $value Value to be amended
+     * @param string $model Optional model to be used
+     * @return mixed
      */
-    public function display($fieldname, $value, $model = null)
+    public function display(string $fieldname, $value, string $model = null)
     {
         $tableName = Inflector::camelize(Inflector::pluralize(str_replace('_id', '', $fieldname)));
         $table = TableRegistry::get($tableName);

--- a/src/Model/Transform/BoolTransform.php
+++ b/src/Model/Transform/BoolTransform.php
@@ -1,21 +1,34 @@
 <?php
+declare(strict_types = 1);
 
 namespace ModelHistory\Model\Transform;
+
+use Cake\Datasource\EntityInterface;
 
 class BoolTransform extends Transform
 {
     /**
-     * {@inheritDoc}
+     * Amend the data before saving.
+     *
+     * @param string $fieldname Field name
+     * @param array $config field config
+     * @param \Cake\Datasource\EntityInterface $entity entity
+     * @return mixed
      */
-    public function save($fieldname, $config, $entity)
+    public function save(string $fieldname, array $config, EntityInterface $entity)
     {
          return $entity->$fieldname;
     }
 
     /**
-     * {@inheritDoc}
+     * Amend the data before displaying.
+     *
+     * @param string $fieldname Field name
+     * @param mixed  $value Value to be amended
+     * @param string $model Optional model to be used
+     * @return mixed
      */
-    public function display($fieldname, $value, $model = null)
+    public function display(string $fieldname, $value, string $model = null)
     {
         $value = $value === true ? 'true' : 'false';
 

--- a/src/Model/Transform/DateTransform.php
+++ b/src/Model/Transform/DateTransform.php
@@ -1,15 +1,22 @@
 <?php
+declare(strict_types = 1);
 
 namespace ModelHistory\Model\Transform;
 
+use Cake\Datasource\EntityInterface;
 use Cake\I18n\Time;
 
 class DateTransform extends Transform
 {
     /**
-     * {@inheritDoc}
+     * Amend the data before saving.
+     *
+     * @param string $fieldname Field name
+     * @param array $config field config
+     * @param \Cake\Datasource\EntityInterface $entity entity
+     * @return mixed
      */
-    public function save($fieldname, $config, $entity)
+    public function save(string $fieldname, array $config, EntityInterface $entity)
     {
         $dateValue = $entity->$fieldname;
         if (!is_object($dateValue)) {
@@ -21,15 +28,20 @@ class DateTransform extends Transform
     }
 
     /**
-     * {@inheritDoc}
+     * Amend the data before displaying.
+     *
+     * @param string $fieldname Field name
+     * @param mixed  $value Value to be amended
+     * @param string $model Optional model to be used
+     * @return mixed
      */
-    public function display($fieldname, $dateValue, $model = null)
+    public function display(string $fieldname, $value, string $model = null)
     {
-        if (!is_object($dateValue)) {
-            $dateValue = new Time($dateValue);
+        if (!is_object($value)) {
+            $value = new Time($value);
         }
-        $dateValue->setTimezone('Europe/Berlin');
+        $value->setTimezone('Europe/Berlin');
 
-        return $dateValue->nice();
+        return $value->nice();
     }
 }

--- a/src/Model/Transform/HashTransform.php
+++ b/src/Model/Transform/HashTransform.php
@@ -1,21 +1,34 @@
 <?php
+declare(strict_types = 1);
 
 namespace ModelHistory\Model\Transform;
+
+use Cake\Datasource\EntityInterface;
 
 class HashTransform extends Transform
 {
     /**
-     * {@inheritDoc}
+     * Amend the data before saving.
+     *
+     * @param string $fieldname Field name
+     * @param array $config field config
+     * @param \Cake\Datasource\EntityInterface $entity entity
+     * @return mixed
      */
-    public function save($fieldname, $config, $entity)
+    public function save(string $fieldname, array $config, EntityInterface $entity)
     {
          return $entity->$fieldname;
     }
 
     /**
-     * {@inheritDoc}
+     * Amend the data before displaying.
+     *
+     * @param string $fieldname Field name
+     * @param mixed  $value Value to be amended
+     * @param string $model Optional model to be used
+     * @return mixed
      */
-    public function display($fieldname, $value, $model = null)
+    public function display(string $fieldname, $value, string $model = null)
     {
         $return = '';
         foreach ($value as $k => $v) {

--- a/src/Model/Transform/MassAssociationTransform.php
+++ b/src/Model/Transform/MassAssociationTransform.php
@@ -1,16 +1,23 @@
 <?php
+declare(strict_types = 1);
 
 namespace ModelHistory\Model\Transform;
 
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 
 class MassAssociationTransform extends Transform
 {
     /**
-     * {@inheritDoc}
+     * Amend the data before saving.
+     *
+     * @param string $fieldname Field name
+     * @param array $config field config
+     * @param \Cake\Datasource\EntityInterface $entity entity
+     * @return mixed
      */
-    public function save($fieldname, $config, $entity = null)
+    public function save(string $fieldname, array $config, EntityInterface $entity = null)
     {
         if (!empty($entity[$config['name']])) {
             $assocData = $entity[$config['name']];
@@ -29,9 +36,14 @@ class MassAssociationTransform extends Transform
     }
 
     /**
-     * {@inheritDoc}
+     * Amend the data before displaying.
+     *
+     * @param string $fieldname Field name
+     * @param mixed  $value Value to be amended
+     * @param string $model Optional model to be used
+     * @return mixed
      */
-    public function display($fieldname, $value, $model = null)
+    public function display(string $fieldname, $value, string $model = null)
     {
         if (is_array($value)) {
             return implode(', ', $value);

--- a/src/Model/Transform/NumberTransform.php
+++ b/src/Model/Transform/NumberTransform.php
@@ -1,21 +1,34 @@
 <?php
+declare(strict_types = 1);
 
 namespace ModelHistory\Model\Transform;
+
+use Cake\Datasource\EntityInterface;
 
 class NumberTransform extends Transform
 {
     /**
-     * {@inheritDoc}
+     * Amend the data before saving.
+     *
+     * @param string $fieldname Field name
+     * @param array $config field config
+     * @param \Cake\Datasource\EntityInterface $entity entity
+     * @return mixed
      */
-    public function save($fieldname, $config, $entity)
+    public function save(string $fieldname, array $config, EntityInterface $entity)
     {
          return $entity->$fieldname;
     }
 
     /**
-     * {@inheritDoc}
+     * Amend the data before displaying.
+     *
+     * @param string $fieldname Field name
+     * @param mixed  $value Value to be amended
+     * @param string $model Optional model to be used
+     * @return mixed
      */
-    public function display($fieldname, $value, $model = null)
+    public function display(string $fieldname, $value, string $model = null)
     {
         return $value;
     }

--- a/src/Model/Transform/RelationTransform.php
+++ b/src/Model/Transform/RelationTransform.php
@@ -1,24 +1,36 @@
 <?php
+declare(strict_types = 1);
 
 namespace ModelHistory\Model\Transform;
 
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 
 class RelationTransform extends Transform
 {
     /**
-     * {@inheritDoc}
+     * Amend the data before saving.
+     *
+     * @param string $fieldname Field name
+     * @param array $config field config
+     * @param \Cake\Datasource\EntityInterface $entity entity
+     * @return mixed
      */
-    public function save($fieldname, $config, $entity)
+    public function save(string $fieldname, array $config, EntityInterface $entity)
     {
          return $entity->$fieldname;
     }
 
     /**
-     * {@inheritDoc}
+     * Amend the data before displaying.
+     *
+     * @param string $fieldname Field name
+     * @param mixed  $value Value to be amended
+     * @param string $model Optional model to be used
+     * @return mixed
      */
-    public function display($fieldname, $value, $model = null)
+    public function display(string $fieldname, $value, string $model = null)
     {
         $tableString = str_replace('_id', '', $fieldname);
         $tableName = Inflector::camelize(Inflector::pluralize($tableString));

--- a/src/Model/Transform/StringTransform.php
+++ b/src/Model/Transform/StringTransform.php
@@ -1,21 +1,34 @@
 <?php
+declare(strict_types = 1);
 
 namespace ModelHistory\Model\Transform;
+
+use Cake\Datasource\EntityInterface;
 
 class StringTransform extends Transform
 {
     /**
-     * {@inheritDoc}
+     * Amend the data before saving.
+     *
+     * @param string $fieldname Field name
+     * @param array $config field config
+     * @param \Cake\Datasource\EntityInterface $entity entity
+     * @return mixed
      */
-    public function save($fieldname, $config, $entity)
+    public function save(string $fieldname, array $config, EntityInterface $entity)
     {
         return $entity->$fieldname;
     }
 
     /**
-     * {@inheritDoc}
+     * Amend the data before displaying.
+     *
+     * @param string $fieldname Field name
+     * @param mixed  $value Value to be amended
+     * @param string $model Optional model to be used
+     * @return mixed
      */
-    public function display($fieldname, $value, $model = null)
+    public function display(string $fieldname, $value, string $model = null)
     {
         return trim($value);
     }

--- a/src/Model/Transform/Transform.php
+++ b/src/Model/Transform/Transform.php
@@ -1,7 +1,9 @@
 <?php
+declare(strict_types = 1);
 
 namespace ModelHistory\Model\Transform;
 
+use Cake\Datasource\EntityInterface;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
 
@@ -9,24 +11,24 @@ abstract class Transform
 {
 
     /**
-     * Amend the data before displaying.
-     *
-     * @param  string $fieldname  Field name
-     * @param  mixed  $value      Value to be amended
-     * @param  string $model      Optional model to be used
-     * @return mixed
-     */
-    abstract public function display($fieldname, $value, $model = null);
-
-    /**
      * Amend the data before saving.
      *
-     * @param  string  $fieldname   Field name
-     * @param  array   $config      field config
-     * @param  mixed   $entity      entity
+     * @param string $fieldname Field name
+     * @param array $config field config
+     * @param \Cake\Datasource\EntityInterface $entity entity
      * @return mixed
      */
-    abstract public function save($fieldname, $config, $entity);
+    abstract public function save(string $fieldname, array $config, EntityInterface $entity);
+
+    /**
+     * Amend the data before displaying.
+     *
+     * @param string $fieldname Field name
+     * @param mixed  $value Value to be amended
+     * @param string $model Optional model to be used
+     * @return mixed
+     */
+    abstract public function display(string $fieldname, $value, string $model = null);
 
     /**
      * Transform factory
@@ -34,7 +36,7 @@ abstract class Transform
      * @param  string  $type  Transform type
      * @return Transform
      */
-    public static function get($type)
+    public static function get(string $type): Transform
     {
         $namespace = '\\ModelHistory\\Model\\Transform\\';
         $transformClass = $namespace . Inflector::camelize($type) . 'Transform';

--- a/src/Template/Element/model_history_area.ctp
+++ b/src/Template/Element/model_history_area.ctp
@@ -1,5 +1,4 @@
 <?php
-use Cake\Routing\Router;
 ?>
 <div class="model-history-wrapper">
     <div class="row">

--- a/src/Template/Element/model_history_rows.ctp
+++ b/src/Template/Element/model_history_rows.ctp
@@ -12,7 +12,13 @@ use ModelHistory\Model\Entity\ModelHistory;
     <?php endif; ?>
     <?php foreach($modelHistory as $historyEntry): ?>
         <tr>
-            <td class="action-label <?= $this->ModelHistory->actionClass($historyEntry->action) ?>" <?php if (!empty($historyEntry->user_id)): ?> data-toggle="popover" data-content="<?= $this->ModelHistory->historyText($historyEntry) ?>"<?php endif; ?>>
+            <td
+                class="action-label <?= $this->ModelHistory->actionClass($historyEntry->action) ?>"
+                <?php if (!empty($historyEntry->user_id)): ?>
+                    data-toggle="popover"
+                    data-content="<?= $this->ModelHistory->historyText($historyEntry) ?>"
+                <?php endif; ?>
+            >
                 <?= $this->ModelHistory->historyBadge($historyEntry) ?>
                 <?= $historyEntry->created->format('d.m.Y, H:i') ?>
                 <?= isset($historyEntry->user) ? '| ' . $historyEntry->user->full_name : '' ?>

--- a/src/View/Helper/ModelHistoryHelper.php
+++ b/src/View/Helper/ModelHistoryHelper.php
@@ -2,6 +2,7 @@
 declare(strict_types = 1);
 namespace ModelHistory\View\Helper;
 
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
@@ -24,10 +25,10 @@ class ModelHistoryHelper extends Helper
     /**
      * Render the model history area where needed
      *
-     * @param \ModelHistory\Model\Entity\ModelHistory $entity One historizable entity
+     * @param \Cake\Datasource\EntityInterface $entity One historizable entity
      * @param array $options options array
      */
-    public function modelHistoryArea(ModelHistory $entity, array $options = []): string
+    public function modelHistoryArea(EntityInterface $entity, array $options = []): string
     {
         $options = Hash::merge([
             'showCommentBox' => false,

--- a/src/View/Helper/ModelHistoryHelper.php
+++ b/src/View/Helper/ModelHistoryHelper.php
@@ -1,12 +1,11 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistory\View\Helper;
 
-use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Cake\View\Helper;
-use Cake\View\View;
 use ModelHistory\Model\Entity\ModelHistory;
 
 /**
@@ -15,16 +14,20 @@ use ModelHistory\Model\Entity\ModelHistory;
 class ModelHistoryHelper extends Helper
 {
 
+    /**
+     * List of helpers used by this helper
+     *
+     * @var array
+     */
     public $helpers = ['Html'];
 
     /**
      * Render the model history area where needed
      *
-     * @param  Entity $entity  one historizable entity
-     * @param  array  $options options array
-     * @return string History area
+     * @param \ModelHistory\Model\Entity\ModelHistory $entity One historizable entity
+     * @param array $options options array
      */
-    public function modelHistoryArea($entity, array $options = [])
+    public function modelHistoryArea(ModelHistory $entity, array $options = []): string
     {
         $options = Hash::merge([
             'showCommentBox' => false,
@@ -70,7 +73,7 @@ class ModelHistoryHelper extends Helper
      * @param  string  $action  History Action
      * @return string
      */
-    public function actionClass($action)
+    public function actionClass(string $action): string
     {
         switch ($action) {
             case ModelHistory::ACTION_CREATE:
@@ -97,7 +100,7 @@ class ModelHistoryHelper extends Helper
      * @param ModelHistory $history one ModelHistory entity
      * @return string
      */
-    public function historyText(ModelHistory $history)
+    public function historyText(ModelHistory $history): string
     {
         $action = '';
         switch ($history->action) {
@@ -133,7 +136,7 @@ class ModelHistoryHelper extends Helper
      * @param ModelHistory $history one ModelHistory entity
      * @return string
      */
-    public function historyBadge(ModelHistory $history)
+    public function historyBadge(ModelHistory $history): string
     {
         $action = '';
         switch ($history->action) {
@@ -161,7 +164,7 @@ class ModelHistoryHelper extends Helper
      * @param  ModelHistory  $historyEntry  A History entry
      * @return string
      */
-    public function getLocalizedFieldnames(ModelHistory $historyEntry)
+    public function getLocalizedFieldnames(ModelHistory $historyEntry): string
     {
         $fields = join(', ', array_map(function ($value) use ($historyEntry) {
             if (!is_string($value)) {
@@ -200,7 +203,7 @@ class ModelHistoryHelper extends Helper
      * @param  ModelHistory  $historyEntry  HistoryEntry entity to get data from
      * @return string
      */
-    public function getLocalizedSlug(ModelHistory $historyEntry)
+    public function getLocalizedSlug(ModelHistory $historyEntry): string
     {
         $slug = $historyEntry->context_slug;
         if (!empty($historyEntry->context) && !empty($historyEntry->context['namespace'])) {

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistory\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;

--- a/tests/Fixture/ArticlesItemsFixture.php
+++ b/tests/Fixture/ArticlesItemsFixture.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistory\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;

--- a/tests/Fixture/ArticlesUsersFixture.php
+++ b/tests/Fixture/ArticlesUsersFixture.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistory\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;

--- a/tests/Fixture/ItemsFixture.php
+++ b/tests/Fixture/ItemsFixture.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistory\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;

--- a/tests/Fixture/ModelHistoryFixture.php
+++ b/tests/Fixture/ModelHistoryFixture.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistory\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistory\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;

--- a/tests/ModelHistoryTestApp/Model/Entity/Article.php
+++ b/tests/ModelHistoryTestApp/Model/Entity/Article.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistoryTestApp\Model\Entity;
 
 use Cake\ORM\Entity;

--- a/tests/ModelHistoryTestApp/Model/Entity/ArticlesItem.php
+++ b/tests/ModelHistoryTestApp/Model/Entity/ArticlesItem.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistoryTestApp\Model\Entity;
 
 use Cake\ORM\Entity;

--- a/tests/ModelHistoryTestApp/Model/Entity/ArticlesUser.php
+++ b/tests/ModelHistoryTestApp/Model/Entity/ArticlesUser.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistoryTestApp\Model\Entity;
 
 use Cake\ORM\Entity;

--- a/tests/ModelHistoryTestApp/Model/Entity/Item.php
+++ b/tests/ModelHistoryTestApp/Model/Entity/Item.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistoryTestApp\Model\Entity;
 
 use Cake\ORM\Entity;

--- a/tests/ModelHistoryTestApp/Model/Entity/User.php
+++ b/tests/ModelHistoryTestApp/Model/Entity/User.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistoryTestApp\Model\Entity;
 
 use Cake\ORM\Entity;

--- a/tests/ModelHistoryTestApp/Model/Table/ArticlesItemsTable.php
+++ b/tests/ModelHistoryTestApp/Model/Table/ArticlesItemsTable.php
@@ -29,25 +29,18 @@ class ArticlesItemsTable extends Table
 
         $this->addBehavior('ModelHistory.Historizable', [
             'fields' => [
-                [
-                    'name' => 'article_id',
+                'article_id' => [
                     'translation' => __('articles_items.article'),
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
                     'type' => 'association',
                     'associationKey' => 'item_id'
                 ],
-                [
-                    'name' => 'item_id',
+                'item_id' => [
                     'translation' => __('articles_items.user'),
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
                     'type' => 'association',
                     'associationKey' => 'article_id'
                 ]
-            ]
+            ],
+            'ignoreFields' => []
         ]);
 
         $this->belongsTo('Articles', [

--- a/tests/ModelHistoryTestApp/Model/Table/ArticlesItemsTable.php
+++ b/tests/ModelHistoryTestApp/Model/Table/ArticlesItemsTable.php
@@ -1,11 +1,8 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistoryTestApp\Model\Table;
 
-use Cake\ORM\Query;
-use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
-use Cake\Validation\Validator;
-use ModelHistoryTestApp\Model\Entity\ArticlesItem;
 
 /**
  * ArticlesItemsTable Model
@@ -19,7 +16,7 @@ class ArticlesItemsTable extends Table
      * @param array $config The configuration for the Table.
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         parent::initialize($config);
 

--- a/tests/ModelHistoryTestApp/Model/Table/ArticlesTable.php
+++ b/tests/ModelHistoryTestApp/Model/Table/ArticlesTable.php
@@ -1,11 +1,9 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistoryTestApp\Model\Table;
 
-use Cake\ORM\Query;
-use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
-use ModelHistoryTestApp\Model\Entity\Article;
 
 /**
  * Articles Model
@@ -19,7 +17,7 @@ class ArticlesTable extends Table
      * @param array $config The configuration for the Table.
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         $this->table('articles');
         $this->displayField('title');
@@ -75,7 +73,7 @@ class ArticlesTable extends Table
      * @param \Cake\Validation\Validator $validator Validator instance.
      * @return \Cake\Validation\Validator
      */
-    public function validationDefault(Validator $validator)
+    public function validationDefault(Validator $validator): \Cake\Validation\Validator
     {
         $validator
             ->add('id', 'valid', ['rule' => 'uuid'])

--- a/tests/ModelHistoryTestApp/Model/Table/ArticlesTable.php
+++ b/tests/ModelHistoryTestApp/Model/Table/ArticlesTable.php
@@ -25,111 +25,48 @@ class ArticlesTable extends Table
         $this->displayField('title');
         $this->primaryKey('id');
         $this->addBehavior('Timestamp');
-        $this->addBehavior('ModelHistory.Historizable', [
-            'userIdCallback' => null,
-            'fields' => [
-                [
-                    'name' => 'id',
-                    'translation' => __('articles.id'),
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
-                    'type' => 'string',
-                    'displayParser' => null,
-                    'saveParser' => null
-                ],
-                [
-                    'name' => 'title',
-                    'translation' => __('articles.title'),
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
-                    'type' => 'string',
-                    'displayParser' => null,
-                    'saveParser' => null
-                ],
-                [
-                    'name' => 'status',
-                    'translation' => __('articles.status'),
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
-                    'type' => 'string',
-                    'displayParser' => null,
-                    'saveParser' => null
-                ],
-                [
-                    'name' => 'content',
-                    'translation' => __('articles.content'),
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
-                    'type' => 'string',
-                    'displayParser' => null,
-                    'saveParser' => null
-                ],
-                [
-                    'name' => 'json_field',
-                    'translation' => __('articles.json_field'),
-                    'searchable' => false,
-                    'saveable' => false,
-                    'obfuscated' => false,
-                    'type' => 'string',
-                    'displayParser' => null,
-                    'saveParser' => null
-                ],
-                [
-                    'name' => 'int_field',
-                    'translation' => __('articles.int_field'),
-                    'searchable' => false,
-                    'saveable' => false,
-                    'obfuscated' => false,
-                    'type' => 'string',
-                    'displayParser' => null,
-                    'saveParser' => null
-                ],
-                [
-                    'name' => 'articles_id',
-                    'translation' => __('articles.articles_id'),
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
-                    'type' => 'relation',
-                    'displayParser' => null,
-                    'saveParser' => null
-                ],
-                [
-                    'name' => 'user_id',
-                    'translation' => __('articles.user_id'),
-                    'searchable' => true,
-                    'saveable' => false,
-                    'obfuscated' => false,
-                    'type' => 'association',
-                    'displayParser' => null,
-                    'saveParser' => null
-                ],
-                [
-                    'name' => 'users',
-                    'translation' => __('articles.users'),
-                    'searchable' => true,
-                    'saveable' => false,
-                    'obfuscated' => false,
-                    'type' => 'mass_association',
-                    'displayParser' => null,
-                    'saveParser' => null
-                ]
-            ],
-            'associated' => [
-                'article.article'
-            ]
-        ]);
 
+        $this->belongsToMany('Items');
         $this->belongsToMany('Users', [
             'foreignKey' => 'article_id',
             'targetForeignKey' => 'user_id',
             'joinTable' => 'articles_users'
         ]);
-        $this->belongsToMany('Items');
+
+        $this->addBehavior('ModelHistory.Historizable', [
+            'userIdCallback' => null,
+            'fields' => [
+                'json_field' => [
+                    'searchable' => false,
+                    'saveable' => false,
+                    'type' => 'string',
+                ],
+                'int_field' => [
+                    'translation' => __('articles.int_field'),
+                    'searchable' => false,
+                    'saveable' => false,
+                    'type' => 'string',
+                ],
+                'articles_id' => [
+                    'translation' => __('articles.articles_id'),
+                    'type' => 'relation',
+                ],
+                'user_id' => [
+                    'translation' => __('articles.user_id'),
+                    'saveable' => false,
+                    'type' => 'association',
+                ],
+                'users' => [
+                    'translation' => __('articles.users'),
+                    'saveable' => false,
+                    'type' => 'mass_association',
+                ]
+            ],
+            'associated' => [
+                'article.article'
+            ],
+            'ignoreFields' => []
+        ]);
     }
 
     /**

--- a/tests/ModelHistoryTestApp/Model/Table/ArticlesUsersTable.php
+++ b/tests/ModelHistoryTestApp/Model/Table/ArticlesUsersTable.php
@@ -1,11 +1,8 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistoryTestApp\Model\Table;
 
-use Cake\ORM\Query;
-use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
-use Cake\Validation\Validator;
-use ModelHistoryTestApp\Model\Entity\ArticlesUser;
 
 /**
  * ArticlesUsersTable Model
@@ -19,7 +16,7 @@ class ArticlesUsersTable extends Table
      * @param array $config The configuration for the Table.
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         parent::initialize($config);
 

--- a/tests/ModelHistoryTestApp/Model/Table/ArticlesUsersTable.php
+++ b/tests/ModelHistoryTestApp/Model/Table/ArticlesUsersTable.php
@@ -29,25 +29,18 @@ class ArticlesUsersTable extends Table
 
         $this->addBehavior('ModelHistory.Historizable', [
             'fields' => [
-                [
-                    'name' => 'article_id',
+                'article_id' => [
                     'translation' => __('articles_users.article'),
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
                     'type' => 'association',
                     'associationKey' => 'user_id'
                 ],
-                [
-                    'name' => 'user_id',
+                'user_id' => [
                     'translation' => __('articles_users.user'),
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
                     'type' => 'association',
                     'associationKey' => 'article_id'
                 ]
-            ]
+            ],
+            'ignoreFields' => []
         ]);
 
         $this->belongsTo('Articles', [

--- a/tests/ModelHistoryTestApp/Model/Table/ItemsTable.php
+++ b/tests/ModelHistoryTestApp/Model/Table/ItemsTable.php
@@ -1,11 +1,9 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistoryTestApp\Model\Table;
 
-use Cake\ORM\Query;
-use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
-use ModelHistoryTestApp\Model\Entity\Item;
 
 /**
  * Items Model
@@ -19,7 +17,7 @@ class ItemsTable extends Table
      * @param array $config The configuration for the Table.
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         $this->table('items');
         $this->displayField('name');
@@ -50,7 +48,7 @@ class ItemsTable extends Table
      * @param \Cake\Validation\Validator $validator Validator instance.
      * @return \Cake\Validation\Validator
      */
-    public function validationDefault(Validator $validator)
+    public function validationDefault(Validator $validator): \Cake\Validation\Validator
     {
         $validator
             ->add('id', 'valid', ['rule' => 'uuid'])

--- a/tests/ModelHistoryTestApp/Model/Table/ItemsTable.php
+++ b/tests/ModelHistoryTestApp/Model/Table/ItemsTable.php
@@ -29,37 +29,12 @@ class ItemsTable extends Table
         $this->addBehavior('ModelHistory.Historizable', [
             'userIdCallback' => null,
             'fields' => [
-                [
-                    'name' => 'id',
-                    'translation' => __('items.id'),
-                    'searchable' => true,
-                    'saveable' => false,
-                    'obfuscated' => false,
-                    'type' => 'string',
-                    'displayParser' => null,
-                    'saveParser' => null
-                ],
-                [
-                    'name' => 'name',
-                    'translation' => __('items.name'),
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
-                    'type' => 'string',
-                    'displayParser' => null,
-                    'saveParser' => null
-                ],
-                [
-                    'name' => 'articles',
+                'articles' => [
                     'translation' => __('items.articles'),
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
                     'type' => 'mass_association',
-                    'displayParser' => null,
-                    'saveParser' => null
                 ]
-            ]
+            ],
+            'ignoreFields' => []
         ]);
 
         $this->belongsToMany('Articles', [

--- a/tests/ModelHistoryTestApp/Model/Table/UsersTable.php
+++ b/tests/ModelHistoryTestApp/Model/Table/UsersTable.php
@@ -1,11 +1,9 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistoryTestApp\Model\Table;
 
-use Cake\ORM\Query;
-use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
-use ModelHistoryTestApp\Model\Entity\User;
 
 /**
  * Users Model
@@ -19,7 +17,7 @@ class UsersTable extends Table
      * @param array $config The configuration for the Table.
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         $this->table('users');
         $this->displayField('firstname');
@@ -56,7 +54,7 @@ class UsersTable extends Table
      * @param \Cake\Validation\Validator $validator Validator instance.
      * @return \Cake\Validation\Validator
      */
-    public function validationDefault(Validator $validator)
+    public function validationDefault(Validator $validator): \Cake\Validation\Validator
     {
         $validator
             ->add('id', 'valid', ['rule' => 'uuid'])

--- a/tests/ModelHistoryTestApp/Model/Table/UsersTable.php
+++ b/tests/ModelHistoryTestApp/Model/Table/UsersTable.php
@@ -28,53 +28,19 @@ class UsersTable extends Table
         $this->addBehavior('ModelHistory.Historizable', [
             'userIdCallback' => null,
             'fields' => [
-                [
-                    'name' => 'id',
-                    'translation' => __('users.id'),
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
-                    'type' => 'string',
-                    'displayParser' => null,
-                    'saveParser' => null
-                ],
-                [
-                    'name' => 'firstname',
+                'firstname' => [
                     'translation' => __('users.firstname'),
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
-                    'type' => 'string',
-                    'displayParser' => null,
-                    'saveParser' => null
                 ],
-                [
-                    'name' => 'lastname',
+                'lastname' => [
                     'translation' => __('users.lastname'),
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
-                    'type' => 'string',
-                    'displayParser' => null,
-                    'saveParser' => null
                 ],
-                [
-                    'name' => 'article_id',
+                'article_id' => [
                     'translation' => __('users.article_id'),
-                    'searchable' => true,
                     'saveable' => false,
-                    'obfuscated' => false,
-                    'type' => 'association'
-                ],
-                [
-                    'name' => 'article_id',
-                    'translation' => __('users.article_id'),
-                    'searchable' => true,
-                    'saveable' => false,
-                    'obfuscated' => false,
                     'type' => 'association'
                 ]
-            ]
+            ],
+            'ignoreFields' => []
         ]);
 
         $this->belongsToMany('Articles', [

--- a/tests/TestCase/Model/Behavior/HistorizableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/HistorizableBehaviorTest.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistory\Test\TestCase\Model\Behavior;
 
 use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
-use ModelHistory\Model\Behavior\HistorizableBehavior;
 use ReflectionClass;
 
 /**
@@ -29,7 +29,7 @@ class HistorizableBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->Articles = TableRegistry::get('ArticlesTable', ['className' => 'ModelHistoryTestApp\Model\Table\ArticlesTable']);
         $this->ModelHistory = TableRegistry::get('ModelHistory', ['className' => 'ModelHistory\Model\Table\ModelHistoryTable']);
@@ -43,7 +43,7 @@ class HistorizableBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Articles);
         unset($this->ModelHistory);
@@ -54,7 +54,7 @@ class HistorizableBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function testGetRelationLink()
+    public function testGetRelationLink(): void
     {
         $userId = '481fc6d0-b920-43e0-a40d-6d1740cf8562';
         $articlesId = '99dbcad7-21d5-4dd1-b193-e00543c0224c';
@@ -72,7 +72,7 @@ class HistorizableBehaviorTest extends TestCase
         $this->assertEquals($fieldValue, $relationLink);
     }
 
-    public function testGetUserNameFields()
+    public function testGetUserNameFields(): void
     {
         $userNameFieldsWithModel = $this->Articles->getUserNameFields();
         $this->assertEquals([
@@ -89,7 +89,7 @@ class HistorizableBehaviorTest extends TestCase
         ], $userNameFieldsWithoutModel);
     }
 
-    public function testRecursivelyExtractObjects()
+    public function testRecursivelyExtractObjects(): void
     {
         $entity1 = $this->Articles->newEntity();
         $entity2 = $this->Articles->newEntity();
@@ -108,7 +108,7 @@ class HistorizableBehaviorTest extends TestCase
         $this->assertEquals($entity3, $res);
     }
 
-    public function testApplySaveHash()
+    public function testApplySaveHash(): void
     {
         $entity1 = $this->Articles->newEntity();
         $entity2 = $this->Articles->newEntity();

--- a/tests/TestCase/Model/Entity/HistoryContextTraitTest.php
+++ b/tests/TestCase/Model/Entity/HistoryContextTraitTest.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistory\Test\TestCase\Model\Entity;
 
 use Cake\Network\Request;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use ModelHistoryTestApp\Model\Entity\Article;
 use ModelHistory\Model\Entity\ModelHistory;
 
 /**
@@ -28,7 +28,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->Articles = TableRegistry::get('ArticlesTable', ['className' => 'ModelHistoryTestApp\Model\Table\ArticlesTable']);
         $this->ModelHistory = TableRegistry::get('ModelHistory', ['className' => 'ModelHistory\Model\Table\ModelHistoryTable']);
@@ -42,7 +42,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Articles);
         unset($this->ModelHistory);
@@ -55,7 +55,7 @@ class ModelHistoryTableTest extends TestCase
      * @expectedException     InvalidArgumentException
      * @return void
      */
-    public function testHistoryContextWrongType()
+    public function testHistoryContextWrongType(): void
     {
         $dataObject = new \stdClass();
         $article = $this->Articles->newEntity();
@@ -68,7 +68,7 @@ class ModelHistoryTableTest extends TestCase
      * @expectedException     InvalidArgumentException
      * @return void
      */
-    public function testSettingFaultyShellContext()
+    public function testSettingFaultyShellContext(): void
     {
         $article = $this->Articles->newEntity();
         $article->setHistoryContext(ModelHistory::CONTEXT_TYPE_SHELL, null);
@@ -80,7 +80,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function testSettingShellContext()
+    public function testSettingShellContext(): void
     {
         $dataObject = new \Cake\Console\Shell();
 
@@ -114,7 +114,7 @@ class ModelHistoryTableTest extends TestCase
      * @expectedException     InvalidArgumentException
      * @return void
      */
-    public function testSettingFaultyControllerContext()
+    public function testSettingFaultyControllerContext(): void
     {
         $article = $this->Articles->newEntity();
         $article->setHistoryContext(ModelHistory::CONTEXT_TYPE_CONTROLLER, null);
@@ -126,7 +126,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function testSettingControllerContext()
+    public function testSettingControllerContext(): void
     {
         $slug = 'a_slug';
         $request = new Request();
@@ -165,7 +165,7 @@ class ModelHistoryTableTest extends TestCase
      * @expectedException     InvalidArgumentException
      * @return void
      */
-    public function testSettingFaultySlugContext()
+    public function testSettingFaultySlugContext(): void
     {
         $article = $this->Articles->newEntity();
         $article->setHistoryContext(ModelHistory::CONTEXT_TYPE_SLUG, null, null);
@@ -177,7 +177,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function testSettingSlugContext()
+    public function testSettingSlugContext(): void
     {
         $slug = 'asdf';
         $article = $this->Articles->newEntity();

--- a/tests/TestCase/Model/Table/ModelHistoryTableTest.php
+++ b/tests/TestCase/Model/Table/ModelHistoryTableTest.php
@@ -74,74 +74,23 @@ class ModelHistoryTableTest extends TestCase
         return [
             'userIdCallback' => $callback,
             'fields' => [
-                [
-                    'name' => 'id',
-                    'translation' => function () {
-                        return __('articles.id');
-                    },
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
-                    'type' => 'string'
-                ],
-                [
-                    'name' => 'title',
-                    'translation' => function () {
-                        return __('articles.title');
-                    },
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
-                    'type' => 'string',
-                    'displayParser' => function ($fieldname, $value, $entity) {
-                        return $value;
-                    },
-                    'saveParser' => function ($fieldname, $value, $entity) {
-                        return $value;
-                    }
-                ],
-                [
-                    'name' => 'status',
-                    'translation' => function () {
-                        return __('articles.status');
-                    },
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
-                    'type' => 'string'
-                ],
-                [
-                    'name' => 'content',
-                    'translation' => function () {
-                        return __('articles.content');
-                    },
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
-                    'type' => 'string'
-                ],
-                [
-                    'name' => 'json_field',
+                'json_field' => [
                     'translation' => function () {
                         return __('articles.json_field');
                     },
                     'searchable' => false,
                     'saveable' => false,
-                    'obfuscated' => false,
                     'type' => 'string'
                 ],
-                [
-                    'name' => 'users',
+                'users' => [
                     'translation' => function () {
                         return __('articles.mass_assoc_field');
                     },
                     'searchable' => false,
                     'saveable' => true,
-                    'obfuscated' => false,
                     'type' => 'mass_association'
                 ],
-                [
-                    'name' => 'int_field',
+                'int_field' => [
                     'translation' => function () {
                         return __('articles.int_field');
                     },
@@ -150,17 +99,16 @@ class ModelHistoryTableTest extends TestCase
                     'obfuscated' => true,
                     'type' => 'string'
                 ],
-                [
-                    'name' => 'user_id',
+                'user_id' => [
                     'translation' => function () {
                         return __('articles.assoc_field');
                     },
                     'searchable' => false,
                     'saveable' => false,
-                    'obfuscated' => false,
                     'type' => 'association'
                 ],
-            ]
+            ],
+            'ignoreFields' => []
         ];
     }
 
@@ -188,7 +136,6 @@ class ModelHistoryTableTest extends TestCase
         $entry = $this->ModelHistory->find()->first();
 
         $this->assertTrue(is_array($entry->data));
-        $this->assertEquals($entry->data['id'], $article->id);
         $this->assertEquals($entry->data['title'], $article->title);
         $this->assertEquals($entry->data['status'], $article->status);
 
@@ -444,17 +391,7 @@ class ModelHistoryTableTest extends TestCase
                 return $userId;
             },
             'fields' => [
-                [
-                    'name' => 'id',
-                    'translation' => function () {
-                        return __('articles.id');
-                    },
-                    'searchable' => true,
-                    'saveable' => true,
-                    'obfuscated' => false,
-                    'type' => 'string'
-                ],
-                [
+                'title' => [
                     'name' => 'title',
                     'translation' => function () {
                         return __('articles.title');
@@ -467,7 +404,7 @@ class ModelHistoryTableTest extends TestCase
                         return $value;
                     }
                 ],
-                [
+                'status' => [
                     'name' => 'status',
                     'translation' => function () {
                         return __('articles.status');
@@ -477,7 +414,7 @@ class ModelHistoryTableTest extends TestCase
                     'obfuscated' => false,
                     'type' => 'string'
                 ],
-                [
+                'content' => [
                     'name' => 'content',
                     'translation' => function () {
                         return __('articles.content');
@@ -487,7 +424,8 @@ class ModelHistoryTableTest extends TestCase
                     'obfuscated' => false,
                     'type' => 'string'
                 ],
-            ]
+            ],
+            'ignoreFields' => []
         ]);
 
         $article = $this->Articles->newEntity([
@@ -588,7 +526,7 @@ class ModelHistoryTableTest extends TestCase
         $articleUser = $this->ArticlesUsers->addBehavior('ModelHistory.Historizable', [
             'userIdCallback' => null,
             'fields' => [
-                [
+                'article_id' => [
                     'name' => 'article_id',
                     'translation' => function () {
                         return __('articles_users.article');
@@ -599,7 +537,7 @@ class ModelHistoryTableTest extends TestCase
                     'type' => 'association',
                     'associationKey' => 'user_id'
                 ],
-                [
+                'user_id' => [
                     'name' => 'user_id',
                     'translation' => function () {
                         return __('articles_users.user');
@@ -610,7 +548,8 @@ class ModelHistoryTableTest extends TestCase
                     'type' => 'association',
                     'associationKey' => 'article_id'
                 ]
-            ]
+            ],
+            'ignoreFields' => []
         ]);
         $articleUser = $this->ArticlesUsers->newEntity([
             'article_id' => '7997df22-ed8e-4703-b971-d9514179904b',

--- a/tests/TestCase/Model/Table/ModelHistoryTableTest.php
+++ b/tests/TestCase/Model/Table/ModelHistoryTableTest.php
@@ -1,16 +1,10 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistory\Test\TestCase\Model\Table;
 
-use App\Lib\Status;
-use Cake\Database\Driver;
-use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use Cake\Utility\Hash;
-use ModelHistoryTestApp\Table\ArticlesTable;
-use ModelHistoryTestApp\Table\ArticlesUsersTable;
 use ModelHistory\Model\Entity\ModelHistory;
-use ModelHistory\Model\Table\ModelHistoryTable;
 
 /**
  * ModelHistory\Model\Table\ModelHistoryTable Test Case
@@ -37,7 +31,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         TableRegistry::clear();
@@ -60,7 +54,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->ModelHistory);
         unset($this->Articles);
@@ -69,7 +63,13 @@ class ModelHistoryTableTest extends TestCase
         parent::tearDown();
     }
 
-    protected function _getBehaviorConfig($callback = null)
+    /**
+     * Get behavior config helper method
+     *
+     * @param callable $callback Callback
+     * @return void
+     */
+    protected function _getBehaviorConfig(callable $callback = null): array
     {
         return [
             'userIdCallback' => $callback,
@@ -117,7 +117,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function testBasicCreateAndUpdateAndDelete()
+    public function testBasicCreateAndUpdateAndDelete(): void
     {
         $this->Articles->addBehavior('ModelHistory.Historizable', $this->_getBehaviorConfig());
         $article = $this->Articles->newEntity([
@@ -169,7 +169,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function testPassUserIdCallbackWithBehaviorConfig()
+    public function testPassUserIdCallbackWithBehaviorConfig(): void
     {
         $userId = '481fc6d0-b920-43e0-a40d-6d1740cf8562';
         $this->Articles->addBehavior('ModelHistory.Historizable', $this->_getBehaviorConfig(function () use ($userId) {
@@ -189,7 +189,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function testPassUserIdCallbackWithMethod()
+    public function testPassUserIdCallbackWithMethod(): void
     {
         $userId = '481fc6d0-b920-43e0-a40d-6d1740cf8562';
         $callback = function () use ($userId) {
@@ -213,7 +213,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function testModelHistoryRevision()
+    public function testModelHistoryRevision(): void
     {
         $this->Articles->addBehavior('ModelHistory.Historizable', $this->_getBehaviorConfig());
         $article = $this->Articles->newEntity([
@@ -255,7 +255,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function testDataDiff()
+    public function testDataDiff(): void
     {
         $this->Articles->addBehavior('ModelHistory.Historizable', $this->_getBehaviorConfig());
         $article = $this->Articles->newEntity([
@@ -286,7 +286,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function testCommenting()
+    public function testCommenting(): void
     {
         $userId = '481fc6d0-b920-43e0-a40d-6d1740cf8562';
         $comment = 'foo bar baz';
@@ -317,7 +317,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function testSearchableFields()
+    public function testSearchableFields(): void
     {
         $this->Articles->addBehavior('ModelHistory.Historizable', $this->_getBehaviorConfig());
         $fields = $this->Articles->getFields();
@@ -339,7 +339,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function testSaveableFields()
+    public function testSaveableFields(): void
     {
         $this->Articles->addBehavior('ModelHistory.Historizable', $this->_getBehaviorConfig());
         $fields = $this->Articles->getFields();
@@ -361,7 +361,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function testGetEntityWithHistory()
+    public function testGetEntityWithHistory(): void
     {
         $userId = '481fc6d0-b920-43e0-a40d-6d1740cf8562';
         $this->Articles->addBehavior('ModelHistory.Historizable', $this->_getBehaviorConfig());
@@ -383,7 +383,7 @@ class ModelHistoryTableTest extends TestCase
         }
     }
 
-    public function testGetModelHistory()
+    public function testGetModelHistory(): void
     {
         $userId = '481fc6d0-b920-43e0-a40d-6d1740cf8562';
         $this->Articles->addBehavior('ModelHistory.Historizable', [
@@ -445,7 +445,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function testBuildDiff()
+    public function testBuildDiff(): void
     {
         $userId = '481fc6d0-b920-43e0-a40d-6d1740cf8562';
         $this->Articles->addBehavior('ModelHistory.Historizable', $this->_getBehaviorConfig());
@@ -521,7 +521,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function testSaveAssociation()
+    public function testSaveAssociation(): void
     {
         $articleUser = $this->ArticlesUsers->addBehavior('ModelHistory.Historizable', [
             'userIdCallback' => null,
@@ -578,7 +578,7 @@ class ModelHistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function testMassAssociation()
+    public function testMassAssociation(): void
     {
         $itemData = [
             'name' => 'foobar',

--- a/tests/TestCase/Model/Transform/TransformTest.php
+++ b/tests/TestCase/Model/Transform/TransformTest.php
@@ -1,11 +1,9 @@
 <?php
+declare(strict_types = 1);
 namespace ModelHistory\Test\TestCase\Model\Transform;
 
-use Cake\Database\Driver;
-use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use ModelHistoryTestApp\Table\ArticlesTable;
 use ModelHistory\Model\Transform\Transform;
 
 /**
@@ -30,7 +28,7 @@ class TransformTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->Articles = TableRegistry::get('ArticlesTable', ['className' => 'ModelHistoryTestApp\Model\Table\ArticlesTable']);
 
@@ -42,7 +40,7 @@ class TransformTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
     }
@@ -53,12 +51,12 @@ class TransformTest extends TestCase
      * @expectedException     InvalidArgumentException
      * @return void
      */
-    public function testFaultyGet()
+    public function testFaultyGet(): void
     {
         Transform::get('fo');
     }
 
-    public function testStringTransformSave()
+    public function testStringTransformSave(): void
     {
         $aritcle = $this->Articles->get('7997df22-ed8e-4703-b971-d9514179904b');
 
@@ -66,7 +64,7 @@ class TransformTest extends TestCase
         $this->assertEquals('check', $trans->save('content', [], $aritcle));
     }
 
-    public function testRelationTransformSave()
+    public function testRelationTransformSave(): void
     {
         $aritcle = $this->Articles->get('7997df22-ed8e-4703-b971-d9514179904b');
 
@@ -74,13 +72,13 @@ class TransformTest extends TestCase
         $this->assertEquals('check', $trans->save('content', [], $aritcle));
     }
 
-    public function testRelationTransformDisplay()
+    public function testRelationTransformDisplay(): void
     {
         $trans = Transform::get('relation');
         $this->assertEquals('7997df22-ed8e-4703-b971-d9514179904b', $trans->display('article_id', '7997df22-ed8e-4703-b971-d9514179904b', null));
     }
 
-    public function testAssociationTransformSave()
+    public function testAssociationTransformSave(): void
     {
         $aritcle = $this->Articles->get('7997df22-ed8e-4703-b971-d9514179904b');
 
@@ -88,7 +86,7 @@ class TransformTest extends TestCase
         $this->assertEquals('check', $trans->save('content', ['associationKey' => 'content'], $aritcle));
     }
 
-    public function testAssociationTransformDisplay()
+    public function testAssociationTransformDisplay(): void
     {
         $trans = Transform::get('association');
         $this->assertEquals('7997df22-ed8e-4703-b971-d9514179904b', $trans->display('article_id', '7997df22-ed8e-4703-b971-d9514179904b', null));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,6 +26,8 @@ if ($vendorPos !== false) {
     $loader = require __DIR__ . '/../vendor/autoload.php';
 }
 
+require_once 'vendor/cakephp/cakephp/src/basics.php';
+
 Cake\Datasource\ConnectionManager::config('test', [
     'className' => 'Cake\Database\Connection',
     'driver' => 'Cake\Database\Driver\Mysql',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 use Cake\Cache\Cache;
 use Cake\Core\Configure;


### PR DESCRIPTION
You now only have to config fields which config values differ from the defaults and fields which are not in the table schema (like foreign_keys in other tables, n:m associations,...)

By default, the fields id, created and modified are ignored. If you want to change that, give an array of field names under 'ignoreFields' into the config. See changes in README for examples and explanation. If you want no fields to be ignored, simply pass an empty array under 'ignoreFields'.